### PR TITLE
docs(contents): 📖 add more info to about in all languages

### DIFF
--- a/.frontmatter/templates/blog.mdx
+++ b/.frontmatter/templates/blog.mdx
@@ -9,6 +9,8 @@ type: blog
 
 ### Reader personas
 
+- xxx
+
 ## Main
 
 ### Preparation
@@ -23,6 +25,14 @@ type: blog
 ## Intro
 
 ### Reader personas
+
+- xxx
+
+### My proficiency level
+
+As of the day I'm writing this article, my proficiency level in this field is as follows:
+
+- xxx
 
 ## Main
 

--- a/src/content/blog/en/astro-and-front-matter-cms-combi.mdx
+++ b/src/content/blog/en/astro-and-front-matter-cms-combi.mdx
@@ -14,7 +14,7 @@ tags:
     - vscode
 level: 1
 description: Detailed explanations of how Front Matter CMS could be the best partner for Astro among all headless CMS, and the configurations I made with some demos.
-modifiedAt: 2024-08-28T04:06:46.680Z
+modifiedAt: 2024-08-29T02:47:27.060Z
 ---
 
 ## Intro
@@ -30,6 +30,14 @@ https://younagi.dev/blog/astro-website/
 - Want to build and run one's own website or blog but overwhelmed by countless options for headless CMS
 - Struggling to find a headless CMS for a website built with Astro
 - Want to see examples of Front Matter CMS in collaboration with Astro
+
+### My proficiency level
+
+As of the day when I'm writing this article, my proficiency level in this field is as follows:
+
+- Have a three-year experience as a software engineer in total (Not in a row)
+- Have never used Front Matter CMS
+- Have built several websites using CMS like WordPress and MicroCMS
 
 ## Main
 

--- a/src/content/blog/en/astro-website.mdx
+++ b/src/content/blog/en/astro-website.mdx
@@ -2,7 +2,7 @@
 title: Build a Personal Website with Astro, Cloudflare Pages, D1, and Front Matter CMS
 description: A quick tour of my personal blog built with Astro, Cloudflare Pages, D1, and Front Matter CMS.
 publishedAt: 2024-07-13T00:34:54.000Z
-modifiedAt: 2024-08-28T04:10:17.511Z
+modifiedAt: 2024-08-29T02:39:36.620Z
 draft: published
 type: blog
 category:
@@ -28,6 +28,14 @@ If you're interested in the code behind my website, see [my Github repo](https:/
 
 - Want to build a website with Astro but have no idea how the whole project structure could be or what kind of features to be added
 - Want to see some examples of the whole project built with Astro
+
+### My proficiency level
+
+As of the day when I'm writing this article, my proficiency level in this field is as follows:
+
+- Have a three-year experience as a software engineer in total (Not in a row)
+- Understand the basics of JavaScript, TypeScript, and Astro
+- Have built several websites using Next.js or Astro
 
 ## Main
 

--- a/src/content/blog/en/pomodoro-shortcut.mdx
+++ b/src/content/blog/en/pomodoro-shortcut.mdx
@@ -3,7 +3,7 @@ title: Free pomodoro timer shortcut built only with the genuine Apple Clock app
 draft: published
 publishedAt: 2024-08-08T03:05:43.193Z
 type: blog
-modifiedAt: 2024-08-28T04:06:19.620Z
+modifiedAt: 2024-08-29T02:50:20.006Z
 category:
   slug: learning
   metadata: en/categories
@@ -29,6 +29,14 @@ That said, it turned out that few of them were really my cup of tea. Some have v
 
 - Want to use a useful pomodoro timer for free
 - Interested in creating a pomodoro timer with the Apple shortcut without any help of third-party apps
+
+### My proficiency level
+
+As of the day when I'm writing this article, my proficiency level in this field is as follows:
+
+- Have a three-year experience as a software engineer in total (Not in a row)
+- Have a one-week experience in creating Apple shortcuts
+- Have created five or so shortcuts
 
 ## Main
 

--- a/src/content/blog/ja/astro-and-front-matter-cms-combi.mdx
+++ b/src/content/blog/ja/astro-and-front-matter-cms-combi.mdx
@@ -14,7 +14,7 @@ tags:
     - vscode
 level: 1
 description: Astro製ウェブサイトのヘッドレスCMSにどうしてFront Matter CMSなのか？という疑問から、チュートリアルでは学べない詳細な設定まで実際のデモも交えて説明する
-modifiedAt: 2024-08-28T04:06:56.537Z
+modifiedAt: 2024-08-29T02:45:40.496Z
 ---
 
 ## 導入
@@ -30,6 +30,14 @@ https://younagi.dev/ja/blog/astro-website/
 - 自分のウェブサイトやブログを開発・運営したいがヘッドレス CMS が多すぎて圧倒されている
 - ちょうど Astro 製ウェブサイトのヘッドレス CMS 探しに苦戦している
 - Front Matter CMS と Astro を組み合わせたプロジェクトの具体例が見たい
+
+### 現時点での私の習熟度
+
+記事執筆時点での私の習熟度は次の通りです。
+
+- ソフトウェアエンジニアとして計 3 年の経験あり(勤続ではない)
+- Front Matter CMS は触ったことがない
+- WordPress や MicroCMS で何度か CMS を使用したウェブサイト制作を経験している
 
 ## 本題
 

--- a/src/content/blog/ja/astro-website.mdx
+++ b/src/content/blog/ja/astro-website.mdx
@@ -2,7 +2,7 @@
 title: Astro + Cloudflare Pages + D1 + Front Matter CMS で個人ウェブサイトを作った
 description: Astro + Cloudflare Pages + D1 + Front Matter CMSの構成で作った個人ウェブサイトの開発体験を簡単に紹介する
 publishedAt: 2024-07-13T00:35:10.000Z
-modifiedAt: 2024-08-28T04:10:12.905Z
+modifiedAt: 2024-08-29T02:43:25.243Z
 draft: published
 type: blog
 category:
@@ -28,6 +28,14 @@ level: 3
 
 - Astro でウェブサイトを作りたいが、プロジェクト全体の構成をどうすればいいのか、どんな機能を実装すればいいのかわからない
 - Astro で作ったプロジェクトの全体像を参考にしたい
+
+### 現時点での私の習熟度
+
+記事執筆時点での私の習熟度は次の通りです。
+
+- ソフトウェアエンジニアとして計 3 年の経験あり(勤続ではない)
+- JavaScript、TypeScript、Astro の基本は理解している
+- Next.js や Astro で何度かウェブサイト制作を経験している
 
 ## 本題
 

--- a/src/content/blog/ja/pomodoro-shortcut.mdx
+++ b/src/content/blog/ja/pomodoro-shortcut.mdx
@@ -3,7 +3,7 @@ title: 【無料ダウンロード】ポモドーロタイマー用ショート�
 draft: published
 publishedAt: 2024-08-08T03:05:43.193Z
 type: blog
-modifiedAt: 2024-08-28T04:06:25.810Z
+modifiedAt: 2024-08-29T02:52:20.385Z
 category:
   slug: learning
   metadata: ja/categories
@@ -31,6 +31,14 @@ description: Apple のショートカット機能と純正時計アプリだけ�
 - 無料で便利なポモドーロタイマーが欲しい
 - Apple のショートカット機能でポモドーロタイマーを作ってみたいが、サードパーティ製のアプリには頼りたくない
 
+### 現時点での私の習熟度
+
+記事執筆時点での私の習熟度は次の通りです。
+
+- ソフトウェアエンジニアとして計 3 年の経験あり(勤続ではない)
+- Apple ショートカット作成は 1 週間程度の経験のみ
+- 5 つほどのショートカットを作成済み
+
 ## 本題
 
 下記リンクから完成品をダウンロードできます。
@@ -38,7 +46,7 @@ description: Apple のショートカット機能と純正時計アプリだけ�
 https://www.icloud.com/shortcuts/b12a5c2e30484677b40a5f98b9e7774d
 
 > [!warning]注意
-> iOS/iPadOS/MacOS のユーザのみ利用可能となります
+> iOS/iPadOS/MacOS のユーザのみ利用可能です
 
 ### 設計コンセプト
 

--- a/src/content/page/en/about.mdx
+++ b/src/content/page/en/about.mdx
@@ -1,12 +1,16 @@
 ---
 title: about
 type: page
-modifiedAt: 2024-08-09T04:43:36.996Z
+modifiedAt: 2024-08-29T02:14:52.194Z
 ---
 
 ## About my website
 
 Here, I offer what I've learnt or experienced in daily lives by posting blog articles or bulletins.
+
+This website is built using [Astro](https://astro.build/), [SolidJS](https://www.solidjs.com/), [Cloudflare Pages](https://pages.cloudflare.com/), etc. If you're interested in more details, see the article below.
+
+https://younagi.dev/blog/astro-website/
 
 ### My stance on this website
 
@@ -34,8 +38,13 @@ When it comes to what I offer, I roughly stick to the following principles:
   - I'm not here to hurt someone else
   - Having said that, I might hurt someone unconsciously because of the potential gaps in what we regard as intense or sensitive
 - **No advertising**
-  - this website contains **NO affiliate links**
-  - I just wanted to say this
+  - this website contains **NO affiliate links** (I just wanted to say that)
+
+### The easy-to-hard level in some articles
+
+Articles categorized as "[Learning](https://younagi.dev/blog/categories/learning/)" have a "Level" field. Bear in mind that this is totally based on my subjective judgment.
+
+You might want to consider my learning level as of the moment I'm writing the article, which is also specified in the article.
 
 ## About me
 
@@ -77,3 +86,9 @@ When it comes to what I offer, I roughly stick to the following principles:
   leftEnd="Generalist"
   rightEnd="Specialist"
 />
+
+### Tastes
+
+#### Music
+
+https://open.spotify.com/playlist/5L5iidyKDSPoRokw955upX?si=a7807b0487f44785

--- a/src/content/page/en/about.mdx
+++ b/src/content/page/en/about.mdx
@@ -1,7 +1,7 @@
 ---
 title: about
 type: page
-modifiedAt: 2024-08-29T02:14:52.194Z
+modifiedAt: 2024-08-29T02:25:05.081Z
 ---
 
 ## About my website
@@ -44,7 +44,7 @@ When it comes to what I offer, I roughly stick to the following principles:
 
 Articles categorized as "[Learning](https://younagi.dev/blog/categories/learning/)" have a "Level" field. Bear in mind that this is totally based on my subjective judgment.
 
-You might want to consider my learning level as of the moment I'm writing the article, which is also specified in the article.
+You might want to consider my proficiency level as of the moment I'm writing the article, which is also specified in the article.
 
 ## About me
 

--- a/src/content/page/ja/about.mdx
+++ b/src/content/page/ja/about.mdx
@@ -1,14 +1,18 @@
 ---
 title: 運営者
 type: page
-modifiedAt: 2024-08-09T04:43:51.538Z
+modifiedAt: 2024-08-29T02:13:44.741Z
 ---
 
 {/* textlint-disable ja-technical-writing/ja-no-weak-phrase */}
 
 ## 当サイトについて
 
-このウェブサイトは、運営者が日常の中で学んだり、経験したことをブログやニュースを通して発信する場です。
+運営者が日常の中で学んだり、経験したことをブログやニュースを通して発信する場です。
+
+このウェブサイトは、[Astro](https://astro.build/)、[SolidJS](https://www.solidjs.com/)、 [Cloudflare Pages](https://pages.cloudflare.com/)などを使用して開発しました。もし開発の詳しい内容に興味があれば、下記の記事をご覧ください。
+
+https://younagi.dev/ja/blog/astro-website/
 
 ### 当サイトのスタンス
 
@@ -36,8 +40,13 @@ modifiedAt: 2024-08-09T04:43:51.538Z
   - 発信した内容を通して誰かを傷つけることは意図していない
   - 人それぞれ基準にする物差しが違うので、意図せず傷つけてしまうことがあるかもしれない
 - **広告ゼロ**
-  - 当サイトは**アフィリエイト広告を利用していません**
-  - 言ってみたかっただけ
+  - 当サイトは**アフィリエイト広告を利用していません**(言ってみたかっただけ)
+
+### 一部記事の「難易度」について
+
+主に「[学び](https://younagi.dev/ja/blog/categories/learning/)」カテゴリの記事には 5 つ星で難易度が設定されていますが、これは完全に私の主観で決めたものです。
+
+記事執筆時点での私の学習レベルも公開していますので、そちらもあわせて参考にしてください。
 
 ## 運営者について
 
@@ -76,3 +85,9 @@ modifiedAt: 2024-08-09T04:43:51.538Z
   leftEnd="ゼネラリスト"
   rightEnd="スペシャリスト"
 />
+
+### 趣味嗜好
+
+#### 音楽
+
+https://open.spotify.com/playlist/5L5iidyKDSPoRokw955upX?si=a7807b0487f44785

--- a/src/content/page/ja/about.mdx
+++ b/src/content/page/ja/about.mdx
@@ -1,7 +1,7 @@
 ---
 title: 運営者
 type: page
-modifiedAt: 2024-08-29T02:13:44.741Z
+modifiedAt: 2024-08-29T02:25:31.160Z
 ---
 
 {/* textlint-disable ja-technical-writing/ja-no-weak-phrase */}
@@ -46,7 +46,7 @@ https://younagi.dev/ja/blog/astro-website/
 
 主に「[学び](https://younagi.dev/ja/blog/categories/learning/)」カテゴリの記事には 5 つ星で難易度が設定されていますが、これは完全に私の主観で決めたものです。
 
-記事執筆時点での私の学習レベルも公開していますので、そちらもあわせて参考にしてください。
+記事執筆時点での私の習熟度合いも公開していますので、そちらもあわせて参考にしてください。
 
 ## 運営者について
 


### PR DESCRIPTION
Changes below are made in line with adding more info to about pages

- Add a "my proficiency level" section to every learning article
- Do the same thing to the blog template